### PR TITLE
Minimum code copyover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM maven:3.5.4-jdk-8-alpine as builder
+MAINTAINER 583114@bah.com
+
+WORKDIR /home
+COPY . .
+
+RUN mvn clean package
+
+FROM openjdk:8u171-jre-alpine
+COPY --from=builder /home/target/jpo-record-parser-0.0.1-SNAPSHOT.jar /home
+
+CMD ["java", "-jar", "/home/jpo-record-parser-0.0.1-SNAPSHOT.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>1.4.1.RELEASE</version>
+		<relativePath /> <!-- lookup parent from repository -->
+	</parent>
+
+	<groupId>usdot.jpo.ode</groupId>
+	<artifactId>jpo-record-parser</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+
+	<packaging>jar</packaging>
+	<name>jpo-record-parser</name>
+	<description>JPO ODE Record Parser Module</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+	    <!-- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients -->
+	    <!--  TODO - will need kafka
+	    <dependency>
+	      <groupId>org.apache.kafka</groupId>
+	      <artifactId>kafka-clients</artifactId>
+	      <version>0.10.1.0</version>
+	    </dependency>
+	    -->
+
+		<dependency>
+			<groupId>org.jmockit</groupId>
+			<artifactId>jmockit</artifactId>
+			<version>1.31</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/us/dot/its/jpo/ingest/Application.java
+++ b/src/main/java/us/dot/its/jpo/ingest/Application.java
@@ -1,0 +1,12 @@
+package us.dot.its.jpo.ingest;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+   public static void main(String[] args) {
+      SpringApplication.run(Application.class, args);
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/IngestProperties.java
+++ b/src/main/java/us/dot/its/jpo/ingest/IngestProperties.java
@@ -1,0 +1,63 @@
+package us.dot.its.jpo.ingest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
+
+@ConfigurationProperties("ingest")
+@PropertySource("classpath:application.properties")
+public class IngestProperties implements EnvironmentAware {
+
+   @Autowired
+   private Environment environment;
+
+   // File import properties
+   private String uploadLocationRoot = "uploads";
+   private String uploadLocationObuLog = "bsmlog";
+   private Integer fileWatcherPeriod = 5; // time to wait between processing inbox directory for new files
+   
+   private int importProcessorBufferSize = 8192;
+
+   @Override
+   public void setEnvironment(Environment environment) {
+      this.environment = environment;
+   }
+
+   public Environment getEnvironment() {
+      return environment;
+   }
+
+   public String getUploadLocationRoot() {
+      return uploadLocationRoot;
+   }
+
+   public void setUploadLocationRoot(String uploadLocationRoot) {
+      this.uploadLocationRoot = uploadLocationRoot;
+   }
+
+   public Integer getFileWatcherPeriod() {
+      return fileWatcherPeriod;
+   }
+
+   public void setFileWatcherPeriod(Integer fileWatcherPeriod) {
+      this.fileWatcherPeriod = fileWatcherPeriod;
+   }
+
+   public String getUploadLocationObuLog() {
+      return uploadLocationObuLog;
+   }
+
+   public void setUploadLocationObuLog(String uploadLocationObuLog) {
+      this.uploadLocationObuLog = uploadLocationObuLog;
+   }
+
+   public int getImportProcessorBufferSize() {
+      return importProcessorBufferSize;
+   }
+
+   public void setImportProcessorBufferSize(int importProcessorBufferSize) {
+      this.importProcessorBufferSize = importProcessorBufferSize;
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/codec/Asn1CodecPublisher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/Asn1CodecPublisher.java
@@ -1,0 +1,12 @@
+package us.dot.its.jpo.ingest.codec;
+
+import java.io.BufferedInputStream;
+
+import us.dot.its.jpo.ingest.codec.LogFileToAsn1CodecPublisher.LogFileToAsn1CodecPublisherException;
+import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher.ImporterFileType;
+
+public interface Asn1CodecPublisher {
+
+   public void publish(BufferedInputStream bis, String fileName, ImporterFileType fileType)
+         throws LogFileToAsn1CodecPublisherException;
+}

--- a/src/main/java/us/dot/its/jpo/ingest/codec/FileAsn1CodecPublisher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/FileAsn1CodecPublisher.java
@@ -1,0 +1,52 @@
+package us.dot.its.jpo.ingest.codec;
+
+import java.io.BufferedInputStream;
+import java.nio.file.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import us.dot.its.jpo.ingest.IngestProperties;
+import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher.ImporterFileType;
+
+public class FileAsn1CodecPublisher {
+
+   public class FileAsn1CodecPublisherException extends Exception {
+
+      private static final long serialVersionUID = 1L;
+
+      public FileAsn1CodecPublisherException(String string, Exception e) {
+         super (string, e);
+      }
+
+   }
+
+   private static final Logger logger = LoggerFactory.getLogger(FileAsn1CodecPublisher.class);
+
+   private LogFileToAsn1CodecPublisher codecPublisher;
+   
+   @Autowired
+   public FileAsn1CodecPublisher(IngestProperties ingestProperties) {
+
+      // TODO - bring in kafka classes
+      
+      // StringPublisher messagePub = new StringPublisher(ingestProperties);
+      // this.codecPublisher = new LogFileToAsn1CodecPublisher(messagePub);
+   }
+
+   public void publishFile(Path filePath, BufferedInputStream fileInputStream, ImporterFileType fileType) 
+         throws FileAsn1CodecPublisherException {
+      String fileName = filePath.toFile().getName();
+
+      logger.info("Publishing file {}", fileName);
+      
+      try {
+         logger.info("Publishing data from {} to asn1_codec.", filePath);
+         codecPublisher.publish(fileInputStream, fileName, fileType);
+      } catch (Exception e) {
+         throw new FileAsn1CodecPublisherException("Failed to publish file.", e);
+      }
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/codec/LogFileToAsn1CodecPublisher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/LogFileToAsn1CodecPublisher.java
@@ -1,0 +1,137 @@
+package us.dot.its.jpo.ingest.codec;
+
+import java.io.BufferedInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher.ImporterFileType;
+import us.dot.its.jpo.ingest.kafka.StringPublisher;
+import us.dot.its.jpo.ingest.parsers.LogFileParser;
+
+public class LogFileToAsn1CodecPublisher implements Asn1CodecPublisher {
+
+   public class LogFileToAsn1CodecPublisherException extends Exception {
+
+      private static final long serialVersionUID = 1L;
+
+      public LogFileToAsn1CodecPublisherException(String string, Exception e) {
+         super (string, e);
+      }
+
+   }
+
+   protected static final Logger logger = LoggerFactory.getLogger(LogFileToAsn1CodecPublisher.class);
+
+   protected StringPublisher publisher;
+   protected LogFileParser fileParser;
+   // TODO - implement or remove serialid
+   //protected SerialId serialId;
+
+   // TODO
+   public LogFileToAsn1CodecPublisher(StringPublisher dataPub) {
+      this.publisher = dataPub;
+      //this.serialId = new SerialId();
+   }
+
+   // TODO
+   @Override
+   public void publish(BufferedInputStream bis, String fileName, ImporterFileType fileType)
+         throws LogFileToAsn1CodecPublisherException {
+      // TODO Auto-generated method stub
+      
+   }
+   
+   // TODO - This needs to be redesigned to publish a proprietary schema
+//   public void publish(BufferedInputStream bis, String fileName, ImporterFileType fileType) 
+//         throws LogFileToAsn1CodecPublisherException {
+//      
+//      // TODO - should be publishing JSON
+//      //XmlUtils xmlUtils = new XmlUtils();
+//      ParserStatus status;
+//
+//      if (fileType == ImporterFileType.OBU_LOG_FILE) {
+//         fileParser = LogFileParser.factory(fileName);
+//      }
+//
+//      List<OdeMsgPayload> payloadList = new ArrayList<>();
+//      do {
+//         try {
+//            status = fileParser.parseFile(bis, fileName);
+//            if (status == ParserStatus.COMPLETE) {
+//               parsePayload(payloadList);
+//            } else if (status == ParserStatus.EOF) {
+//               publish(xmlUtils, payloadList);
+//            } else if (status == ParserStatus.INIT) {
+//               logger.error("Failed to parse the header bytes.");
+//            } else {
+//               logger.error("Failed to decode ASN.1 data");
+//            }
+//         } catch (Exception e) {
+//            throw new LogFileToAsn1CodecPublisherException("Error parsing or publishing data.", e);
+//         }
+//      } while (status == ParserStatus.COMPLETE);
+//   }
+
+   
+   // TODO - This needs to be redesigned to publish a proprietary schema
+   
+//   public void parsePayload(List<OdeMsgPayload> payloadList) {
+//
+//      OdeMsgPayload msgPayload;
+//      
+//      if (fileParser instanceof DriverAlertFileParser){
+//         msgPayload = new OdeDriverAlertPayload(((DriverAlertFileParser) fileParser).getAlert());
+//      } else {
+//         msgPayload = new OdeAsn1Payload(fileParser.getPayloadParser().getPayload());
+//      }
+//
+//      payloadList.add(msgPayload);
+//   }
+//
+//   public void publish(XmlUtils xmlUtils, List<OdeMsgPayload> payloadList) throws JsonProcessingException {
+//     serialId.setBundleSize(payloadList.size());
+//     for (OdeMsgPayload msgPayload : payloadList) {
+//       OdeLogMetadata msgMetadata;
+//       OdeData msgData;
+//       
+//       if (fileParser instanceof DriverAlertFileParser){
+//          logger.debug("Publishing a driverAlert.");
+//
+//          msgMetadata = new OdeLogMetadata(msgPayload);
+//          msgMetadata.setSerialId(serialId);
+//
+//          OdeLogMetadataCreatorHelper.updateLogMetadata(msgMetadata, fileParser);
+//          
+//          msgData = new OdeDriverAlertData(msgMetadata, msgPayload);
+//          publisher.publish(JsonUtils.toJson(msgData, false),
+//             publisher.getOdeProperties().getKafkaTopicDriverAlertJson());
+//          serialId.increment();
+//       } else {
+//          if (fileParser instanceof BsmLogFileParser || 
+//                (fileParser instanceof RxMsgFileParser && ((RxMsgFileParser)fileParser).getRxSource() == RxSource.RV)) {
+//             logger.debug("Publishing a BSM");
+//             msgMetadata = new OdeBsmMetadata(msgPayload);
+//          } else {
+//             logger.debug("Publishing a TIM");
+//             msgMetadata = new OdeLogMetadata(msgPayload);
+//          }
+//          msgMetadata.setSerialId(serialId);
+//
+//          Asn1Encoding msgEncoding = new Asn1Encoding("root", "Ieee1609Dot2Data", EncodingRule.COER);
+//          Asn1Encoding unsecuredDataEncoding = new Asn1Encoding("unsecuredData", "MessageFrame",
+//                  EncodingRule.UPER);
+//          msgMetadata.addEncoding(msgEncoding).addEncoding(unsecuredDataEncoding);
+//
+//          OdeLogMetadataCreatorHelper.updateLogMetadata(msgMetadata, fileParser);
+//          
+//          msgData = new OdeAsn1Data(msgMetadata, msgPayload);
+//          publisher.publish(xmlUtils.toXml(msgData),
+//             publisher.getOdeProperties().getKafkaTopicAsn1DecoderInput());
+//          serialId.increment();
+//       }
+//     }
+//   }
+
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/codec/utils/CodecUtils.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/utils/CodecUtils.java
@@ -1,0 +1,197 @@
+package us.dot.its.jpo.ingest.codec.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import javax.xml.bind.DatatypeConverter;
+
+public class CodecUtils {
+
+   private CodecUtils() {
+   }
+
+   /**
+    * Converts an array of shorts to a byte array.
+    * <p>
+    * Example: (short) 5 will be stored as {0, 5} since 5 = 00000000 00000101
+    * </p>
+    * <p>
+    * Example: (short) 257 will be stored as {1, 1} since 257 = 00000001
+    * 00000001
+    * </p>
+    * 
+    * @param shorts
+    * @return byte array containing shorts as their byte value
+    */
+   public static byte[] shortsToBytes(short[] shorts) {
+      ByteBuffer buffer = ByteBuffer.allocate(shorts.length * 2).order(ByteOrder.BIG_ENDIAN);
+      for (short num : shorts) {
+         buffer.putShort(num);
+      }
+      return buffer.array();
+   }
+
+   /**
+    * Converts a single short to a byte array length 2. See
+    * {@link #shortsToBytes(short[])}
+    * 
+    * @param number
+    * @return byte array containing short as a 2-byte array
+    */
+   public static byte[] shortToBytes(short number) {
+      short[] shorts = new short[] { number };
+      return shortsToBytes(shorts);
+   }
+
+   /**
+    * Converts an array of bytes to an array of shorts and returns the first
+    * element. See {@link #bytesToShorts(byte[])}
+    * 
+    * @param bytes
+    * @return array of shorts
+    */
+   public static short bytesToShort(byte[] bytes, int offset, int length, ByteOrder bo) {
+      return bytesToShorts(bytes, offset, length, bo)[0];
+   }
+
+   /**
+    * Converts an array of bytes to an array of shorts.
+    * <p>
+    * Example: {(byte) 1, (byte) 1} will return {(short) 257} since 257 =
+    * 00000001 00000001
+    * </p>
+    * 
+    * @param bytes
+    * @return array of shorts
+    */
+   public static short[] bytesToShorts(byte[] bytes, int offset, int length, ByteOrder bo) {
+      ByteBuffer buffer = ByteBuffer.allocate(length).order(bo);
+      buffer.put(bytes, offset, length);
+      buffer.flip();
+      int numberOfShorts = length / 2;
+      short[] shorts = new short[numberOfShorts];
+      for (int i = 0; i < numberOfShorts; i++) {
+         shorts[i] = buffer.getShort();
+      }
+      return shorts;
+   }
+
+   /**
+    * Combines byte arrays.
+    * 
+    * @param bytes
+    * @return combined array
+    * @throws IOException
+    */
+
+   public static byte[] mergeBytes(byte[]... bytes) throws IOException {
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+      for (byte[] bArray : bytes) {
+         outputStream.write(bArray);
+      }
+      return outputStream.toByteArray();
+   }
+
+   public static int bytesToInt(byte[] bytes, int offset, int length, ByteOrder bo) {
+      return bytesToInts(bytes, offset, length, bo)[0];
+   }
+
+   public static int[] bytesToInts(byte[] bytes, int offset, int length, ByteOrder bo) {
+      ByteBuffer buffer = ByteBuffer.allocate(length).order(bo);
+      buffer.put(bytes, offset, length);
+      buffer.flip();
+      int numberOfInts = length / 4;
+      int[] ints = new int[numberOfInts];
+      for (int i = 0; i < numberOfInts; i++) {
+         ints[i] = buffer.getInt();
+      }
+      return ints;
+   }
+
+   public static long bytesToLong(byte[] bytes, int offset, int length, ByteOrder bo) {
+      return bytesToLongs(bytes, offset, length, bo)[0];
+   }
+
+   public static long[] bytesToLongs(byte[] bytes, int offset, int length, ByteOrder bo) {
+      ByteBuffer buffer = ByteBuffer.allocate(length).order(bo);
+      buffer.put(bytes, offset, length);
+      buffer.flip();
+      int numberOfLongs = length / 8;
+      long[] longs = new long[numberOfLongs];
+      for (int i = 0; i < numberOfLongs; i++) {
+         longs[i] = buffer.getLong();
+      }
+      return longs;
+   }
+
+   public static String toHex(byte[] bytes) {
+      return bytes != null ? DatatypeConverter.printHexBinary(bytes) : "";
+   }
+   
+   public static String toHex(byte b) {
+      return DatatypeConverter.printHexBinary(new byte[]{b});
+   }
+
+   public static byte[] fromHex(String hex) {
+      return DatatypeConverter.parseHexBinary(hex);
+   }
+
+   public static String toBase64(byte[] bytes) {
+      return bytes != null ? DatatypeConverter.printBase64Binary(bytes) : "";
+   }
+
+   public static byte[] fromBase64(String base64) {
+      return DatatypeConverter.parseBase64Binary(base64);
+   }
+
+   /**
+    * @param strShort
+    *           String representation of a short integer value in binary or hex
+    *           format. If the string is in binary format, the length must be
+    *           exactly 16 1s and zeros. If Hex format, the length must be
+    *           exactly 4 Hex digits.
+    * 
+    * @return a byte array equivalent of strShort
+    */
+   public static byte[] shortStringToByteArray(String strShort) {
+
+      byte[] byteArrayValue = null;
+
+      int radix = radixOf(strShort);
+
+      if (radix == 0) {
+         byteArrayValue = new byte[2]; // NOSONAR
+      } else {
+         byteArrayValue = Arrays
+               .copyOfRange(ByteBuffer.allocate(4).putInt(Integer.parseUnsignedInt(strShort, radix)).array(), 2, 4);
+      }
+
+      return byteArrayValue;
+   }
+
+   /**
+    * @param strShort
+    *           String representation of a short integer value in binary or hex
+    *           format. If strShort is in binary format, the length must be
+    *           exactly 16 ones and zeros. If strShort is in Hex format, the
+    *           length must be exactly 4 Hex digits.
+    * @return The radix of the strShort: Currently supporting only binary and
+    *         hex, therefore the return value is either 2 or 16
+    */
+   private static int radixOf(String strShort) {
+      int radix = 0;
+      if (strShort == null || strShort.length() == 0) {
+         radix = 0;
+      } else if (strShort.length() == 16) {
+         radix = 2;
+      } else if (strShort.length() == 4) {
+         radix = 16;
+      } else {
+         throw new IllegalArgumentException("Short String length is invalid: " + strShort.length());
+      }
+      return radix;
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/codec/utils/DateTimeUtils.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/utils/DateTimeUtils.java
@@ -1,0 +1,78 @@
+package us.dot.its.jpo.ingest.codec.utils;
+
+import java.text.ParseException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class DateTimeUtils {
+
+   private DateTimeUtils() {
+   }
+
+   public static String now() {
+      return nowZDT().format(DateTimeFormatter.ISO_INSTANT);
+   }
+
+   public static ZonedDateTime nowZDT() {
+      return ZonedDateTime.now(ZoneId.of("UTC"));
+   }
+
+   public static String isoDateTime(ZonedDateTime zonedDateTime) {
+      return zonedDateTime.format(DateTimeFormatter.ISO_INSTANT);
+   }
+
+   public static ZonedDateTime
+         isoDateTime(int year, int month, int dayOfMonth, int hourOfDay, int minute, int second, int millisec) {
+      return ZonedDateTime.of(year, month, dayOfMonth, hourOfDay, minute, second, millisec * 1000000, ZoneOffset.UTC);
+   }
+
+   public static ZonedDateTime isoDateTime(String s) throws ParseException {
+      return ZonedDateTime.parse(s);
+   }
+
+   public static ZonedDateTime isoDateTime(Date date) {
+      return ZonedDateTime.from(date.toInstant().atZone(ZoneId.of("UTC")));
+   }
+
+   public static ZonedDateTime isoDateTime(long epockMillis) {
+      return ZonedDateTime.ofInstant(Instant.ofEpochMilli(epockMillis), ZoneId.of("UTC"));
+   }
+
+   public static boolean
+         isBetweenTimesInclusive(ZonedDateTime dateTime, ZonedDateTime startDateTime, ZonedDateTime endDateTime) {
+
+      if (dateTime == null)
+         return true;
+
+      if (startDateTime == null) {
+         if (endDateTime == null) {// Both startDate and endDate are null, so
+                                   // it's false
+            return true;
+         } else {// We only have the endDate, so any dateTime not after the
+                 // endDateTime is true
+            return !dateTime.isAfter(endDateTime);
+         }
+      } else {
+         if (endDateTime == null) {// We only have the startDateTime, so any
+                                   // dateTime not before the startDateTime is
+                                   // true
+            return !dateTime.isBefore(startDateTime);
+         } else {// We have both startDateTime and endDateTime, so any dateTime
+                 // not before the startDate and not after endDateTime is true
+            return !dateTime.isBefore(startDateTime) && !dateTime.isAfter(endDateTime);
+         }
+      }
+   }
+
+   public static long difference(ZonedDateTime t1, ZonedDateTime t2) {
+      return t2.toInstant().toEpochMilli() - t1.toInstant().toEpochMilli();
+   }
+
+   public static Long elapsedTime(ZonedDateTime zonedDateTime) {
+      return difference(zonedDateTime, ZonedDateTime.now());
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/controllers/FileUploadController.java
+++ b/src/main/java/us/dot/its/jpo/ingest/controllers/FileUploadController.java
@@ -1,0 +1,88 @@
+package us.dot.its.jpo.ingest.controllers;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import us.dot.its.jpo.ingest.IngestProperties;
+import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher;
+import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher.ImporterFileType;
+import us.dot.its.jpo.ingest.storage.StorageFileNotFoundException;
+import us.dot.its.jpo.ingest.storage.StorageService;
+
+@RestController
+public class FileUploadController {
+   // TODO - These should be moved into ODE
+   //private static final String FILTERED_OUTPUT_TOPIC = "/topic/filtered_messages";
+   //private static final String UNFILTERED_OUTPUT_TOPIC = "/topic/unfiltered_messages";
+
+   private static Logger logger = LoggerFactory.getLogger(FileUploadController.class);
+
+   private final StorageService storageService;
+
+   @Autowired
+   public FileUploadController(StorageService storageService, IngestProperties ingestProperties) {
+      super();
+      this.storageService = storageService;
+
+      ExecutorService threadPool = Executors.newCachedThreadPool();
+
+      Path logPath = Paths.get(ingestProperties.getUploadLocationRoot(), ingestProperties.getUploadLocationObuLog());
+      logger.debug("UPLOADER - BSM log file upload directory: {}", logPath);
+      Path failurePath = Paths.get(ingestProperties.getUploadLocationRoot(), "failed");
+      logger.debug("UPLOADER - Failure directory: {}", failurePath);
+      Path backupPath = Paths.get(ingestProperties.getUploadLocationRoot(), "backup");
+      logger.debug("UPLOADER - Backup directory: {}", backupPath);
+
+      // Create the importers that watch folders for new/modified files
+      threadPool.submit(new ImporterDirectoryWatcher(ingestProperties, logPath, backupPath, failurePath,
+            ImporterFileType.OBU_LOG_FILE, ingestProperties.getFileWatcherPeriod()));
+
+      // TODO - These should be moved into ODE
+
+      // Create unfiltered exporters
+//      threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeBsmJson()));
+//      threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeTimJson()));
+//      threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicDriverAlertJson()));
+//      threadPool.submit(new StompStringExporter(odeProperties, UNFILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicOdeTimBroadcastJson()));
+
+      // Create filtered exporters
+//      threadPool.submit(new StompStringExporter(odeProperties, FILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicFilteredOdeBsmJson()));
+//      threadPool.submit(new StompStringExporter(odeProperties, FILTERED_OUTPUT_TOPIC, template, odeProperties.getKafkaTopicFilteredOdeTimJson()));
+   }
+
+   @PostMapping("/upload/{type}")
+   public ResponseEntity<String> handleFileUpload(@RequestParam("file") MultipartFile file,
+         @PathVariable("type") String type) {
+
+      logger.debug("File received at endpoint: /upload/{}, name={}", type, file.getOriginalFilename());
+      try {
+         storageService.store(file, type);
+      } catch (Exception e) {
+         logger.error("File storage error", e);
+         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("{\"Error\": \"File storage error.\"}");
+         // do not return exception, XSS vulnerable
+      }
+
+      return ResponseEntity.status(HttpStatus.OK).body("{\"Success\": \"True\"}");
+   }
+
+   @ExceptionHandler(StorageFileNotFoundException.class)
+   public ResponseEntity<Void> handleStorageFileNotFound(StorageFileNotFoundException exc) {
+      return ResponseEntity.notFound().build();
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/importer/ImporterDirectoryWatcher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/importer/ImporterDirectoryWatcher.java
@@ -1,0 +1,87 @@
+package us.dot.its.jpo.ingest.importer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import us.dot.its.jpo.ingest.IngestProperties;
+import us.dot.its.jpo.ingest.storage.IngestFileUtils;
+
+public class ImporterDirectoryWatcher implements Runnable {
+   
+   public enum ImporterFileType {
+      OBU_LOG_FILE
+   }
+
+   private static final Logger logger = LoggerFactory.getLogger(ImporterDirectoryWatcher.class);
+
+   private boolean watching;
+
+   private ImporterProcessor importerProcessor;
+
+   private Path inbox;
+   private Path backup;
+   private Path failed;
+
+   private ScheduledExecutorService executor;
+
+   private Integer timePeriod;
+
+   public ImporterDirectoryWatcher(IngestProperties ingestProperties, Path dir, Path backupDir, Path failureDir, ImporterFileType fileType, Integer timePeriod) {
+      this.inbox = dir;
+      this.backup = backupDir;
+      this.failed = failureDir;
+      this.watching = true;
+      this.timePeriod = timePeriod;
+
+      try {
+         IngestFileUtils.createDirectoryRecursively(inbox);
+         String msg = "Created directory {}";
+         logger.debug(msg, inbox);
+         IngestFileUtils.createDirectoryRecursively(failed);
+         logger.debug(msg, failed);
+         IngestFileUtils.createDirectoryRecursively(backup);
+         logger.debug(msg, backup);
+      } catch (IOException e) {
+         logger.error("Error creating directory: " + inbox, e);
+      }
+
+      this.importerProcessor = new ImporterProcessor(ingestProperties, fileType);
+      
+      executor = Executors.newScheduledThreadPool(1);
+   }
+
+   @Override
+   public void run() {
+
+      logger.info("Processing inbox directory {} every {} seconds.", inbox, timePeriod);
+
+      // ODE-646: the old method of watching the directory used file
+      // event notifications and was unreliable for large quantities of files
+      // Watch directory for file events
+      executor.scheduleWithFixedDelay(() -> importerProcessor.processDirectory(inbox, backup, failed),
+          0, timePeriod, TimeUnit.SECONDS);
+      
+      try {
+         // This line will only execute in the event that .scheduleWithFixedDelay() throws an error
+         executor.awaitTermination(timePeriod, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         logger.error("Directory watcher polling loop interrupted!", e);
+      }
+   }
+
+   public boolean isWatching() {
+      return watching;
+   }
+
+   public void setWatching(boolean watching) {
+      this.watching = watching;
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/importer/ImporterProcessor.java
+++ b/src/main/java/us/dot/its/jpo/ingest/importer/ImporterProcessor.java
@@ -1,0 +1,124 @@
+package us.dot.its.jpo.ingest.importer;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import us.dot.its.jpo.ingest.IngestProperties;
+import us.dot.its.jpo.ingest.codec.FileAsn1CodecPublisher;
+import us.dot.its.jpo.ingest.codec.FileAsn1CodecPublisher.FileAsn1CodecPublisherException;
+import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher.ImporterFileType;
+import us.dot.its.jpo.ingest.storage.IngestFileUtils;
+
+public class ImporterProcessor {
+
+   private static final Logger logger = LoggerFactory.getLogger(ImporterProcessor.class);
+   private FileAsn1CodecPublisher codecPublisher;
+   private IngestProperties ingestProperties;
+   private ImporterFileType fileType;
+   private Pattern gZipPattern = Pattern.compile("application/.*gzip");
+   private Pattern zipPattern = Pattern.compile("application/.*zip.*");
+
+   public ImporterProcessor(IngestProperties ingestProperties, ImporterFileType fileType) {
+      this.codecPublisher = new FileAsn1CodecPublisher(ingestProperties);
+      this.ingestProperties = ingestProperties;
+      this.fileType = fileType;
+   }
+
+   public int processDirectory(Path dir, Path backupDir, Path failureDir) {
+      int count = 0;
+      // Process files already in the directory
+      try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+
+         for (Path entry : stream) {
+            if (entry.toFile().isDirectory()) {
+               processDirectory(entry, backupDir, failureDir);
+            } else {
+               logger.debug("Found a file to process: {}", entry.getFileName());
+               processAndBackupFile(entry, backupDir, failureDir);
+               count++;
+            }
+         }
+
+      } catch (Exception e) {
+         logger.error("Error processing files.", e);
+      }
+      return count;
+   }
+
+   public void processAndBackupFile(Path filePath, Path backupDir, Path failureDir) {
+
+      // ODE-559
+      boolean success = true;
+      InputStream inputStream = null;
+      BufferedInputStream bis = null;
+
+      try {
+         inputStream = new FileInputStream(filePath.toFile());
+         String probeContentType = Files.probeContentType(filePath);
+         if ((probeContentType != null && gZipPattern.matcher(probeContentType).matches()) || filePath.toString().toLowerCase().endsWith("gz")) {
+            logger.info("Treating as gzip file");
+            inputStream = new GZIPInputStream(inputStream);
+            bis = publishFile(filePath, inputStream);
+         } else if ((probeContentType != null && zipPattern.matcher(probeContentType).matches()) || filePath.toString().endsWith("zip")) {
+            logger.info("Treating as zip file");
+            inputStream = new ZipInputStream(inputStream);
+            ZipInputStream zis = (ZipInputStream)inputStream;
+            while (zis.getNextEntry() != null) {
+               bis = publishFile(filePath, inputStream);
+            }
+         } else {
+            logger.info("Treating as unknown file");
+            bis = publishFile(filePath, inputStream);
+         }
+      } catch (Exception e) {
+         success = false;
+         logger.error("Failed to open or process file: " + filePath, e);
+         //EventLogger.logger.error("Failed to open or process file: " + filePath, e);  
+      } finally {
+         try {
+            if (bis != null) {
+               bis.close();
+            }
+            if (inputStream != null) {
+               inputStream.close();
+            }
+         } catch (IOException e) {
+            logger.error("Failed to close file stream: {}", e);
+         }
+      }
+
+      try {
+         if (success) {
+            IngestFileUtils.backupFile(filePath, backupDir);
+            logger.info("File moved to backup: {}", backupDir);
+            //EventLogger.logger.info("File moved to backup: {}", backupDir);  
+         } else {
+            IngestFileUtils.moveFile(filePath, failureDir);
+            logger.info("File moved to failure directory: {}", failureDir);  
+            //EventLogger.logger.info("File moved to failure directory: {}", failureDir);
+         }
+      } catch (IOException e) {
+         logger.error("Unable to backup file: " + filePath, e);
+      }
+   }
+
+   private BufferedInputStream publishFile(Path filePath, InputStream inputStream)
+         throws FileAsn1CodecPublisherException {
+      BufferedInputStream bis;
+      bis = new BufferedInputStream(inputStream, ingestProperties.getImportProcessorBufferSize());
+      codecPublisher.publishFile(filePath, bis, fileType);
+      return bis;
+   }
+}
+

--- a/src/main/java/us/dot/its/jpo/ingest/kafka/StringPublisher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/kafka/StringPublisher.java
@@ -1,0 +1,7 @@
+package us.dot.its.jpo.ingest.kafka;
+
+public class StringPublisher {
+   
+   // TODO - implement
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/BsmLogFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/BsmLogFileParser.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BsmLogFileParser extends LogFileParser {
+   
+   // TODO - ripped from OdeBsmMetadata class
+   public enum BsmSource {
+      EV, RV, unknown
+   }
+   
+   private static final Logger logger = LoggerFactory.getLogger(BsmLogFileParser.class);
+
+   private static final int DIRECTION_LENGTH = 1;
+
+   private BsmSource bsmSource; // 0 for EV(Tx), 1 for RV(Rx)
+
+   public BsmLogFileParser() {
+      super();
+      setLocationParser(new LocationParser());
+      setTimeParser(new TimeParser());
+      setSecResCodeParser(new SecurityResultCodeParser());
+      setPayloadParser(new PayloadParser());
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status;
+      try {
+         status = super.parseFile(bis, fileName);
+         if (status != ParserStatus.COMPLETE)
+            return status;
+
+         if (getStep() == 1) {
+            status = parseStep(bis, DIRECTION_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setBsmSource(readBuffer);
+         }
+         
+         
+         if (getStep() == 2) {
+            status = nextStep(bis, fileName, locationParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+         
+         if (getStep() == 3) {
+            status = nextStep(bis, fileName, timeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 4) {
+            status = nextStep(bis, fileName, secResCodeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 5) {
+            status = nextStep(bis, fileName, payloadParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+         
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException("Error parsing " + fileName, e);
+      }
+
+      return status;
+   }
+
+   public BsmSource getBsmSource() {
+      return bsmSource;
+   }
+
+   public void setBsmSource(BsmSource bsmSource) {
+      this.bsmSource = bsmSource;
+   }
+
+   public void setBsmSource(byte[] code) {
+      try {
+         setBsmSource(BsmSource.values()[code[0]]);
+      } catch (Exception e) {
+         logger.error("Invalid BsmSource: {}. Valid values are {}-{} inclusive", 
+            code, 0, BsmSource.values());
+         setBsmSource(BsmSource.unknown);
+      }
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/DistressMsgFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/DistressMsgFileParser.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+
+public class DistressMsgFileParser extends LogFileParser {
+
+   public DistressMsgFileParser() {
+      super();
+      setLocationParser(new LocationParser());
+      setTimeParser(new TimeParser());
+      setSecResCodeParser(new SecurityResultCodeParser());
+      setPayloadParser(new PayloadParser());
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status;
+      try {
+         status = super.parseFile(bis, fileName);
+         if (status != ParserStatus.COMPLETE)
+            return status;
+
+         if (getStep() == 1) {
+            status = nextStep(bis, fileName, locationParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+         
+         if (getStep() == 2) {
+            status = nextStep(bis, fileName, timeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 3) {
+            status = nextStep(bis, fileName, secResCodeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 4) {
+            status = nextStep(bis, fileName, payloadParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+         
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+      return status;
+
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/DriverAlertFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/DriverAlertFileParser.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+
+public class DriverAlertFileParser extends LogFileParser {
+
+   private String alert;
+
+   public DriverAlertFileParser() {
+      super();
+      setLocationParser(new LocationParser());
+      setTimeParser(new TimeParser());
+      setPayloadParser(new PayloadParser());
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status;
+      try {
+         status = super.parseFile(bis, fileName);
+         if (status != ParserStatus.COMPLETE)
+            return status;
+
+         if (getStep() == 1) {
+            status = nextStep(bis, fileName, locationParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+         
+         if (getStep() == 2) {
+            status = nextStep(bis, fileName, timeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 3) {
+            status = nextStep(bis, fileName, payloadParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setAlert(payloadParser.getPayload());
+         }
+
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+      return status;
+   }
+
+   public String getAlert() {
+      return alert;
+   }
+
+   public void setAlert(byte[] alert) {
+      this.alert = new String(alert);
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/FileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/FileParser.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+
+public interface FileParser {
+
+   public static class FileParserException extends Exception {
+      public FileParserException(String msg) {
+         super(msg);
+      }
+
+      public FileParserException(String msg, Exception e) {
+         super(msg, e);
+      }
+
+      private static final long serialVersionUID = 1L;
+
+   }
+
+   public enum ParserStatus {
+      UNKNOWN, INIT, NA, PARTIAL, COMPLETE, EOF, ERROR
+   }
+
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException;
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/LocationParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/LocationParser.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+import java.nio.ByteOrder;
+
+import us.dot.its.jpo.ingest.codec.utils.CodecUtils;
+
+public class LocationParser extends LogFileParser {
+
+   public static final int LOCATION_LAT_LENGTH = 4;
+   public static final int LOCATION_LON_LENGTH = 4;
+   public static final int LOCATION_ELEV_LENGTH = 4;
+   public static final int LOCATION_SPEED_LENGTH = 2;
+   public static final int LOCATION_HEADING_LENGTH = 2;
+
+   protected LogLocation location;
+
+   public LocationParser() {
+      super();
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status = ParserStatus.INIT;
+
+      try {
+         this.location = new LogLocation();
+   
+         // Step 1 - parse location.latitude
+         if (getStep() == 0) {
+            status = parseStep(bis, LOCATION_LAT_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            location.setLatitude(CodecUtils.bytesToInt(readBuffer, 0, LOCATION_LAT_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+   
+         // Step 2 - parse location.longitude
+         if (getStep() == 1) {
+            status = parseStep(bis, LOCATION_LON_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            location.setLongitude(CodecUtils.bytesToInt(readBuffer, 0, LOCATION_LON_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+   
+         // Step 3 - parse location.elevation
+         if (getStep() == 2) {
+            status = parseStep(bis, LOCATION_ELEV_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            location.setElevation(CodecUtils.bytesToInt(readBuffer, 0, LOCATION_ELEV_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+   
+         // Step 4 - parse location.speed
+         if (getStep() == 3) {
+            status = parseStep(bis, LOCATION_SPEED_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            location.setSpeed(CodecUtils.bytesToShort(readBuffer, 0, LOCATION_SPEED_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+   
+         // Step 5 - parse location.heading
+         if (getStep() == 4) {
+            status = parseStep(bis, LOCATION_HEADING_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            location.setHeading(CodecUtils.bytesToShort(readBuffer, 0, LOCATION_HEADING_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+   
+         resetStep();
+         status = ParserStatus.COMPLETE;
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+
+      return status;
+   }
+
+   public LogLocation getLocation() {
+      return location;
+   }
+
+   public LocationParser setLocation(LogLocation location) {
+      this.location = location;
+      return this;
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/LogFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/LogFileParser.java
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class LogFileParser implements FileParser {
+   
+   // TODO - ripped from OdeLogMetadata class
+   public enum RecordType {
+      bsmLogDuringEvent, rxMsg, dnMsg, bsmTx, driverAlert, unsupported
+   }
+   
+   private static final Logger logger = LoggerFactory.getLogger(LogFileParser.class);
+
+   public static final int BUFFER_SIZE = 4096;
+
+   protected byte[] readBuffer = new byte[BUFFER_SIZE];
+   protected int step = 0;
+
+   protected String filename;
+   protected RecordType recordType;
+
+   protected LocationParser locationParser;
+   protected TimeParser timeParser;
+   protected SecurityResultCodeParser secResCodeParser;
+   protected PayloadParser payloadParser;
+
+   public LogFileParser() {
+      super();
+   }
+
+   public static LogFileParser factory(String fileName) {
+      LogFileParser fileParser;
+      if (fileName.startsWith(RecordType.bsmTx.name())) {
+         logger.debug("Parsing as \"Transmit BSM \" log file type.");
+         fileParser = new BsmLogFileParser().setRecordType(RecordType.bsmTx);
+      } else if (fileName.startsWith(RecordType.bsmLogDuringEvent.name())) {
+         logger.debug("Parsing as \"BSM For Event\" log file type.");
+         fileParser = new BsmLogFileParser().setRecordType(RecordType.bsmLogDuringEvent);
+      } else if (fileName.startsWith(RecordType.rxMsg.name())) {
+         logger.debug("Parsing as \"Received Messages\" log file type.");
+         fileParser = new RxMsgFileParser().setRecordType(RecordType.rxMsg);
+      } else if (fileName.startsWith(RecordType.dnMsg.name())) {
+         logger.debug("Parsing as \"Distress Notifications\" log file type.");
+         fileParser = new DistressMsgFileParser().setRecordType(RecordType.dnMsg);
+      } else if (fileName.startsWith(RecordType.driverAlert.name())) {
+         logger.debug("Parsing as \"Driver Alert\" log file type.");
+         fileParser = new DriverAlertFileParser().setRecordType(RecordType.driverAlert);
+      } else {
+         throw new IllegalArgumentException("Unknown log file prefix: " + fileName);
+      }
+      return fileParser;
+   }
+
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) 
+         throws FileParserException {
+
+      if (getStep() == 0) {
+         setFilename(fileName);
+         setStep(getStep() + 1);
+      }
+
+      return ParserStatus.COMPLETE;
+   }
+
+   public ParserStatus parseStep(BufferedInputStream bis, int length) throws FileParserException {
+      if (length > BUFFER_SIZE) {
+         throw new FileParserException("Data size of " + length 
+               + " is larger than allocated buffer size of " + BUFFER_SIZE);
+      }
+      
+      try {
+         int numBytes;
+         if (bis.markSupported()) {
+            bis.mark(length);
+         }
+         numBytes = bis.read(readBuffer, 0, length);
+         if (numBytes < 0) {
+            return ParserStatus.EOF;
+         } else if (numBytes < length) {
+            if (bis.markSupported()) {
+               try {
+                  bis.reset();
+               } catch (IOException ioe) {
+                  throw new FileParserException("Error reseting Input Stream to marked position", ioe);
+               }
+            }
+            return ParserStatus.PARTIAL;
+         } else {
+            step++;
+            return ParserStatus.COMPLETE;
+         }
+      } catch (Exception e) {
+         throw new FileParserException("Error parsing step " + step, e);
+      }
+   }
+
+   public int getStep() {
+      return step;
+   }
+
+   public LogFileParser setStep(int step) {
+      this.step = step;
+      return this;
+   }
+
+   protected int resetStep() {
+      return setStep(0).getStep();
+   }
+   
+   protected ParserStatus nextStep(
+      BufferedInputStream bis, 
+      String fileName, 
+      LogFileParser parser) throws FileParserException {
+      
+      ParserStatus status = parser.parseFile(bis, fileName);
+      if (status == ParserStatus.COMPLETE) {
+         step++;
+      }
+      return status;
+   }
+
+   public String getFilename() {
+      return filename;
+   }
+
+   public LogFileParser setFilename(String filename) {
+      this.filename = filename;
+      return this;
+   }
+
+   public RecordType getRecordType() {
+      return recordType;
+   }
+
+   public LogFileParser setRecordType(RecordType recordType) {
+      this.recordType = recordType;
+      return this;
+   }
+
+   public LocationParser getLocationParser() {
+      return locationParser;
+   }
+
+   public void setLocationParser(LocationParser locationParser) {
+      this.locationParser = locationParser;
+   }
+
+   public TimeParser getTimeParser() {
+      return timeParser;
+   }
+
+   public void setTimeParser(TimeParser timeParser) {
+      this.timeParser = timeParser;
+   }
+
+   public SecurityResultCodeParser getSecResCodeParser() {
+      return secResCodeParser;
+   }
+
+   public void setSecResCodeParser(SecurityResultCodeParser secResCodeParser) {
+      this.secResCodeParser = secResCodeParser;
+   }
+
+   public PayloadParser getPayloadParser() {
+      return payloadParser;
+   }
+
+   public void setPayloadParser(PayloadParser payloadParser) {
+      this.payloadParser = payloadParser;
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/LogLocation.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/LogLocation.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+/**
+ * POJO class for TIM log file location data
+ */
+public class LogLocation {
+
+   private int latitude;
+   private int longitude;
+   private int elevation;
+   private short speed;
+   private short heading;
+
+   public LogLocation() {
+      super();
+   }
+
+   public int getLatitude() {
+      return latitude;
+   }
+
+   public void setLatitude(int latitude) {
+      this.latitude = latitude;
+   }
+
+   public int getLongitude() {
+      return longitude;
+   }
+
+   public void setLongitude(int longitude) {
+      this.longitude = longitude;
+   }
+
+   public int getElevation() {
+      return elevation;
+   }
+
+   public void setElevation(int elevation) {
+      this.elevation = elevation;
+   }
+
+   public short getSpeed() {
+      return speed;
+   }
+
+   public void setSpeed(short speed) {
+      this.speed = speed;
+   }
+
+   public short getHeading() {
+      return heading;
+   }
+
+   public void setHeading(short heading) {
+      this.heading = heading;
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/PayloadParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/PayloadParser.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+import us.dot.its.jpo.ingest.codec.utils.CodecUtils;
+
+public class PayloadParser extends LogFileParser {
+
+   public static final int PAYLOAD_LENGTH_LENGTH = 2;
+
+   protected short payloadLength;
+   protected byte[] payload;
+
+   public PayloadParser() {
+      super();
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status = ParserStatus.INIT;
+      try {
+         // parse payload length
+         if (getStep() == 0) {
+            status = parseStep(bis, PAYLOAD_LENGTH_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setPayloadLength(CodecUtils.bytesToShort(readBuffer, 0, PAYLOAD_LENGTH_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+
+         // Step 10 - copy payload bytes
+         if (getStep() == 1) {
+            status = parseStep(bis, getPayloadLength());
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setPayload(Arrays.copyOf(readBuffer, getPayloadLength()));
+         }
+         
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+      return status;
+
+   }
+   
+   public short getPayloadLength() {
+      return payloadLength;
+   }
+
+   public LogFileParser setPayloadLength(short length) {
+      this.payloadLength = length;
+      return this;
+   }
+
+   public byte[] getPayload() {
+      return payload;
+   }
+
+   public LogFileParser setPayload(byte[] payload) {
+      this.payload = payload;
+      return this;
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/RxMsgFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/RxMsgFileParser.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RxMsgFileParser extends LogFileParser {
+   
+   // TODO - ripped from ODE RxSource class in core/common
+   public enum RxSource {
+      RSU, SAT, RV, SNMP, NA, unknown
+   }
+
+   private static final Logger logger = LoggerFactory.getLogger(RxMsgFileParser.class);
+
+   private static final int RX_SOURCE_LENGTH = 1;
+   
+   private RxSource rxSource;
+
+   public RxMsgFileParser() {
+      super();
+      setLocationParser(new LocationParser());
+      setTimeParser(new TimeParser());
+      setSecResCodeParser(new SecurityResultCodeParser());
+      setPayloadParser(new PayloadParser());
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status;
+      try {
+         status = super.parseFile(bis, fileName);
+         if (status != ParserStatus.COMPLETE)
+            return status;
+
+         // parse rxSource
+         if (getStep() == 1) {
+            status = parseStep(bis, RX_SOURCE_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setRxSource(RxSource.values()[readBuffer[0]]);
+         }
+
+         if (getStep() == 2) {
+            status = nextStep(bis, fileName, locationParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+         
+         if (getStep() == 3) {
+            status = nextStep(bis, fileName, timeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 4) {
+            status = nextStep(bis, fileName, secResCodeParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         if (getStep() == 5) {
+            status = nextStep(bis, fileName, payloadParser);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+         }
+
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+      return status;
+
+   }
+
+   public RxSource getRxSource() {
+      return rxSource;
+   }
+
+   public void setRxSource(RxSource rxSource) {
+      this.rxSource = rxSource;
+   }
+
+   public void setRxSource(int rxSourceOrdinal) {
+      try {
+         setRxSource(RxSource.values()[rxSourceOrdinal]);
+      } catch (Exception e) {
+         logger.error("Invalid RxSource: {}. Valid values are {}: ", 
+            rxSourceOrdinal, RxSource.values());
+         setRxSource(RxSource.unknown);
+      }
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/SecurityResultCodeParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/SecurityResultCodeParser.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecurityResultCodeParser extends LogFileParser {
+   
+   // TODO - ripped from OdeLogMetadata
+   public enum SecurityResultCode {
+      success,
+      unknown,
+      inconsistentInputParameters,
+      spduParsingInvalidInput,
+      spduParsingUnsupportedCriticalInformationField,
+      spduParsingCertificateNotFound,
+      spduParsingGenerationTimeNotAvailable,
+      spduParsingGenerationLocationNotAvailable,
+      spduCertificateChainNotEnoughInformationToConstructChain,
+      spduCertificateChainChainEndedAtUntrustedRoot,
+      spduCertificateChainChainWasTooLongForImplementation,
+      spduCertificateChainCertificateRevoked,
+      spduCertificateChainOverdueCRL,
+      spduCertificateChainInconsistentExpiryTimes,
+      spduCertificateChainInconsistentStartTimes,
+      spduCertificateChainInconsistentChainPermissions,
+      spduCryptoVerificationFailure,
+      spduConsistencyFutureCertificateAtGenerationTime,
+      spduConsistencyExpiredCertificateAtGenerationTime,
+      spduConsistencyExpiryDateTooEarly,
+      spduConsistencyExpiryDateTooLate,
+      spduConsistencyGenerationLocationOutsideValidityRegion,
+      spduConsistencyNoGenerationLocation,
+      spduConsistencyUnauthorizedPSID,
+      spduInternalConsistencyExpiryTimeBeforeGenerationTime,
+      spduInternalConsistencyextDataHashDoesntMatch,
+      spduInternalConsistencynoExtDataHashProvided,
+      spduInternalConsistencynoExtDataHashPresent,
+      spduLocalConsistencyPSIDsDontMatch,
+      spduLocalConsistencyChainWasTooLongForSDEE,
+      spduRelevanceGenerationTimeTooFarInPast,
+      spduRelevanceGenerationTimeTooFarInFuture,
+      spduRelevanceExpiryTimeInPast,
+      spduRelevanceGenerationLocationTooDistant,
+      spduRelevanceReplayedSpdu,
+      spduCertificateExpired
+   }
+
+   private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+   public static final int SECURITY_RESULT_CODE_LENGTH = 1;
+
+   protected SecurityResultCode securityResultCode;
+
+   public SecurityResultCodeParser() {
+      super();
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status = ParserStatus.INIT;
+      try {
+         // parse SecurityResultCode
+         if (getStep() == 0) {
+            status = parseStep(bis, SECURITY_RESULT_CODE_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setSecurityResultCode(readBuffer[0]);
+         }
+         
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+      return status;
+
+   }
+
+   public SecurityResultCode getSecurityResultCode() {
+      return securityResultCode;
+   }
+
+   public void setSecurityResultCode(SecurityResultCode securityResultCode) {
+      this.securityResultCode = securityResultCode;
+   }
+
+   public void setSecurityResultCode(byte code) {
+      try {
+         setSecurityResultCode(SecurityResultCode.values()[code]);
+      } catch (Exception e) {
+         logger.error("Invalid SecurityResultCode: {}. Valid values are {}: ", 
+            code, SecurityResultCode.values());
+         setSecurityResultCode(SecurityResultCode.unknown);
+      }
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/TimeParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/TimeParser.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright 2018 572682
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package us.dot.its.jpo.ingest.parsers;
+
+import java.io.BufferedInputStream;
+import java.nio.ByteOrder;
+import java.time.ZonedDateTime;
+
+import us.dot.its.jpo.ingest.codec.utils.CodecUtils;
+import us.dot.its.jpo.ingest.codec.utils.DateTimeUtils;
+
+public class TimeParser extends LogFileParser {
+
+   public static final int UTC_TIME_IN_SEC_LENGTH = 4;
+   public static final int MSEC_LENGTH = 2;
+
+   protected long utcTimeInSec;
+   protected short mSec;
+
+   public TimeParser() {
+      super();
+   }
+
+   @Override
+   public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException {
+
+      ParserStatus status = ParserStatus.INIT;
+      try {
+         // parse utcTimeInSec
+         if (getStep() == 0) {
+            status = parseStep(bis, UTC_TIME_IN_SEC_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setUtcTimeInSec(CodecUtils.bytesToInt(readBuffer, 0, UTC_TIME_IN_SEC_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+
+         // parse mSec
+         if (getStep() == 1) {
+            status = parseStep(bis, MSEC_LENGTH);
+            if (status != ParserStatus.COMPLETE)
+               return status;
+            setmSec(CodecUtils.bytesToShort(readBuffer, 0, MSEC_LENGTH, ByteOrder.LITTLE_ENDIAN));
+         }
+
+         resetStep();
+         status = ParserStatus.COMPLETE;
+
+      } catch (Exception e) {
+         throw new FileParserException(String.format("Error parsing %s on step %d", fileName, getStep()), e);
+      }
+
+      return status;
+   }
+   
+   public long getUtcTimeInSec() {
+      return utcTimeInSec;
+   }
+
+   public LogFileParser setUtcTimeInSec(long utcTimeInSec) {
+      this.utcTimeInSec = utcTimeInSec;
+      return this;
+   }
+
+   public short getmSec() {
+      return mSec;
+   }
+
+   public LogFileParser setmSec(short mSec) {
+      this.mSec = mSec;
+      return this;
+   }
+
+   public ZonedDateTime getGeneratedAt() {
+      return DateTimeUtils.isoDateTime(getUtcTimeInSec() * 1000 + getmSec());
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/storage/FileSystemStorageService.java
+++ b/src/main/java/us/dot/its/jpo/ingest/storage/FileSystemStorageService.java
@@ -1,0 +1,131 @@
+package us.dot.its.jpo.ingest.storage;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.FileSystemUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import us.dot.its.jpo.ingest.IngestProperties;
+
+@Service
+public class FileSystemStorageService implements StorageService {
+    private static Logger logger = LoggerFactory.getLogger(FileSystemStorageService.class);
+
+    private Path rootLocation;
+    private Path logFileLocation;
+
+    @Autowired
+    public FileSystemStorageService(IngestProperties ingestProperties) {
+
+        this.rootLocation = Paths.get(ingestProperties.getUploadLocationRoot());
+        this.logFileLocation = Paths.get(ingestProperties.getUploadLocationRoot(), 
+           ingestProperties.getUploadLocationObuLog());
+
+        logger.info("Upload location (root): {}", this.rootLocation);
+        logger.info("Upload location (OBU log file): {}", this.logFileLocation);
+    }
+
+    @Override
+    public void store(MultipartFile file, String type) {
+
+        // Discern the destination path via the file type (bsm or messageFrame)
+        Path path;
+        if (("bsmlog").equals(type) || ("obulog").equals(type)) {
+           path = this.logFileLocation.resolve(file.getOriginalFilename());
+        } else {
+            //EventLogger.logger.info("File type unknown: {} {}", type, file.getName());
+            throw new StorageException("File type unknown: " + type + " " + file.getName());
+        }
+
+        // Check file is not empty
+        if (file.isEmpty()) {
+            //EventLogger.logger.info("File is empty: {}", path);
+            throw new StorageException("File is empty: " + path);
+        }
+
+        // Check file does not already exist (if so, delete existing)
+        try {
+            //EventLogger.logger.info("Deleting existing file: {}", path);
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            //EventLogger.logger.info("Failed to delete existing file: {} ", path);
+            throw new StorageException("Failed to delete existing file: " + path, e);
+        }
+
+        // Copy the file to the relevant directory
+        try {
+            logger.debug("Copying file {} to {}", file.getOriginalFilename(), path);
+            //EventLogger.logger.info("Copying file {} to {}", file.getOriginalFilename(), path);
+            Files.copy(file.getInputStream(), path);
+        } catch (Exception e) {
+            //EventLogger.logger.info("Failed to store file in shared directory {}", path);
+            throw new StorageException("Failed to store file in shared directory " + path, e);
+        }
+    }
+
+    @Override
+    public Stream<Path> loadAll() {
+        try {
+            return Files.walk(this.rootLocation, 1).filter(path -> !path.equals(this.rootLocation))
+                    .map(path -> this.rootLocation.relativize(path));
+        } catch (IOException e) {
+            //EventLogger.logger.info("Failed to read files stored in {}", this.rootLocation);
+            throw new StorageException("Failed to read files stored in " + this.rootLocation, e);
+        }
+    }
+
+    @Override
+    public Path load(String filename) {
+        return rootLocation.resolve(filename);
+    }
+
+    @Override
+    public Resource loadAsResource(String filename) {
+        try {
+            Path file = load(filename);
+            Resource resource = new UrlResource(file.toUri());
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            } else {
+                throw new StorageFileNotFoundException("Could not read file: " + filename);
+            }
+        } catch (MalformedURLException e) {
+            throw new StorageFileNotFoundException("Could not read file: " + filename, e);
+        }
+    }
+
+    @Override
+    public void deleteAll() {
+        FileSystemUtils.deleteRecursively(rootLocation.toFile());
+        //EventLogger.logger.info("Deleting {}", this.rootLocation);
+    }
+
+    @Override
+    public void init() {
+        try {
+            Files.createDirectory(rootLocation);
+        } catch (IOException e) {
+            //EventLogger.logger.info("Failed to initialize storage service {}", this.rootLocation);
+            throw new StorageException("Failed to initialize storage service " + this.rootLocation, e);
+        }
+    }
+
+    public Path getRootLocation() {
+        return rootLocation;
+    }
+
+    public void setRootLocation(Path rootLocation) {
+        this.rootLocation = rootLocation;
+    }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/storage/IngestFileUtils.java
+++ b/src/main/java/us/dot/its/jpo/ingest/storage/IngestFileUtils.java
@@ -1,0 +1,90 @@
+package us.dot.its.jpo.ingest.storage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+public class IngestFileUtils {
+
+   private IngestFileUtils() {
+   }
+
+   /**
+    * Attempts to create a directory given a String path.
+    * 
+    * @param dir
+    * @throws IOException
+    */
+   public static void createDirectoryRecursively(Path dir) throws IOException {
+
+      // Attempt to create a directory
+      try {
+         Files.createDirectories(dir);
+      } catch (IOException e) {
+         throw new IOException("Exception while trying to create directory: " + e);
+      }
+
+      // Verify the directory was successfully created
+      if (!dir.toFile().exists()) {
+         throw new IOException("Failed to verify directory creation - directory does not exist.");
+      }
+
+   }
+
+   /**
+    * Attempts to move a file to a backup directory. Prepends the filename with
+    * the current time and changes the file extension to 'pbo'.
+    * 
+    * @param file
+    *           Path of the file being moved
+    * @param backup
+    *           Path of backup directory
+    * @throws IOException
+    */
+   public static void backupFile(Path file, Path backupDir) throws IOException {
+
+      // Check that the destination directory actually exists before moving the
+      // file
+      if (!backupDir.toFile().exists()) {
+         throw new IOException("Backup directory does not exist: " + backupDir);
+      }
+
+      // Prepend file name with time and change extension to 'pbo'
+      String processedFileName = Integer.toString((int) System.currentTimeMillis()) + "-"
+            + file.getFileName().toString().replaceFirst("uper", "pbo");
+      Path targetPath = Paths.get(backupDir.toString(), processedFileName);
+
+      // Attempt to move the file to the backup directory
+      try {
+         Files.move(file, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException e) {
+         throw new IOException("Unable to move file to backup: " + e);
+      }
+   }
+   
+   /**
+    * Attempts to move and overwrite a file to destination directory. Throws exception if directory doesn't exist or move failed.
+    * @param file
+    * @param destination
+    * @throws IOException 
+    */
+   public static void moveFile(Path file, Path destination) throws IOException {
+   // Check that the destination directory actually exists before moving the
+      // file
+      if (!destination.toFile().exists()) {
+         throw new IOException("Directory does not exist: " + destination);
+      }
+
+      Path targetPath = Paths.get(destination.toString(), file.getFileName().toString());
+
+      // Attempt to move the file to the backup directory
+      try {
+         Files.move(file, targetPath, StandardCopyOption.REPLACE_EXISTING);
+      } catch (IOException e) {
+         throw new IOException("Unable to move file to backup: " + e);
+      }
+   }
+}
+

--- a/src/main/java/us/dot/its/jpo/ingest/storage/StorageException.java
+++ b/src/main/java/us/dot/its/jpo/ingest/storage/StorageException.java
@@ -1,0 +1,14 @@
+package us.dot.its.jpo.ingest.storage;
+
+public class StorageException extends RuntimeException {
+
+   private static final long serialVersionUID = 1L;
+
+   public StorageException(String message) {
+        super(message);
+    }
+
+    public StorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/storage/StorageFileNotFoundException.java
+++ b/src/main/java/us/dot/its/jpo/ingest/storage/StorageFileNotFoundException.java
@@ -1,0 +1,16 @@
+package us.dot.its.jpo.ingest.storage;
+
+import us.dot.its.jpo.ingest.storage.StorageException;
+
+public class StorageFileNotFoundException extends StorageException {
+
+   private static final long serialVersionUID = 1L;
+
+   public StorageFileNotFoundException(String message) {
+        super(message);
+    }
+
+    public StorageFileNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/storage/StorageService.java
+++ b/src/main/java/us/dot/its/jpo/ingest/storage/StorageService.java
@@ -1,0 +1,23 @@
+package us.dot.its.jpo.ingest.storage;
+
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.springframework.core.io.Resource;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StorageService {
+
+   void init();
+
+   void store(MultipartFile file, String type);
+
+   Stream<Path> loadAll();
+
+   Path load(String filename);
+
+   Resource loadAsResource(String filename);
+
+   void deleteAll();
+
+}


### PR DESCRIPTION
### Summary
This is a pull request to pull in what I see as the absolute minimum amount of code from the ODE. 

### Changes
- OdeProperties is now IngestProperties and the required properties and getters/setters have been copied over

### Fixes needed for MVP
- The `publish` and `parsePayload` methods of LogFileAsn1CodecPublisher.java were commented out. They need to be implemented and redesigned, to remove the metadata operations. We want all metadata operations to be done by the ODE, so these methods here should be a minimal parse and publish setup.
- Kafka classes were not copied over. Since our ODE Kafka setup is very heavily abstracted and generified, I think it would be better for us to create a new, minimal string publisher here.
- DateTimeUtils and CodecUtils were copied over in full - we can probably cut out the pieces we really want
- Several `enum` types have been copied over from the Metadata classes of the ODE, likely we want to have a discussion about what to do with these.

### Other changes needed
- Log file specific POJO classes should probably be created and pushed into the upcoming ODE SDK library
- ODE will need to change how and where it ingests this data and how metadata is added/processed