### PR TITLE
Add basic pojo populating functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
 	      <version>0.10.1.0</version>
 	    </dependency>
 	    -->
+	    
+        <dependency>
+	      <groupId>com.google.code.gson</groupId>
+	      <artifactId>gson</artifactId>
+	    </dependency>
 
 		<dependency>
 			<groupId>org.jmockit</groupId>

--- a/src/main/java/us/dot/its/jpo/ingest/codec/LogFileToAsn1CodecPublisher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/LogFileToAsn1CodecPublisher.java
@@ -1,13 +1,17 @@
 package us.dot.its.jpo.ingest.codec;
 
 import java.io.BufferedInputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import us.dot.its.jpo.ingest.importer.ImporterDirectoryWatcher.ImporterFileType;
 import us.dot.its.jpo.ingest.kafka.StringPublisher;
+import us.dot.its.jpo.ingest.parsers.FileParser.ParserStatus;
 import us.dot.its.jpo.ingest.parsers.LogFileParser;
+import us.dot.its.jpo.ingest.pojos.Record;
 
 public class LogFileToAsn1CodecPublisher implements Asn1CodecPublisher {
 
@@ -25,113 +29,44 @@ public class LogFileToAsn1CodecPublisher implements Asn1CodecPublisher {
 
    protected StringPublisher publisher;
    protected LogFileParser fileParser;
-   // TODO - implement or remove serialid
-   //protected SerialId serialId;
 
    // TODO
    public LogFileToAsn1CodecPublisher(StringPublisher dataPub) {
       this.publisher = dataPub;
-      //this.serialId = new SerialId();
    }
-
-   // TODO
-   @Override
-   public void publish(BufferedInputStream bis, String fileName, ImporterFileType fileType)
+   
+//    TODO - This needs to be redesigned to publish a proprietary schema
+   public void publish(BufferedInputStream bis, String fileName, ImporterFileType fileType) 
          throws LogFileToAsn1CodecPublisherException {
-      // TODO Auto-generated method stub
       
+      ParserStatus status;
+
+      if (fileType == ImporterFileType.OBU_LOG_FILE) {
+         fileParser = LogFileParser.factory(fileName);
+      }
+
+      List<Record> recordList = new ArrayList<>();
+      do {
+         try {
+            status = fileParser.parseFile(bis, fileName);
+            if (status == ParserStatus.COMPLETE) {
+               recordList.add(fileParser.getCurrentRecord());
+            } else if (status == ParserStatus.EOF) {
+               publishRecordList(recordList);
+            } else if (status == ParserStatus.INIT) {
+               logger.error("Failed to parse the header bytes.");
+            } else {
+               logger.error("Failed to decode ASN.1 data");
+            }
+         } catch (Exception e) {
+            throw new LogFileToAsn1CodecPublisherException("Error parsing or publishing data.", e);
+         }
+      } while (status == ParserStatus.COMPLETE);
    }
    
-   // TODO - This needs to be redesigned to publish a proprietary schema
-//   public void publish(BufferedInputStream bis, String fileName, ImporterFileType fileType) 
-//         throws LogFileToAsn1CodecPublisherException {
-//      
-//      // TODO - should be publishing JSON
-//      //XmlUtils xmlUtils = new XmlUtils();
-//      ParserStatus status;
-//
-//      if (fileType == ImporterFileType.OBU_LOG_FILE) {
-//         fileParser = LogFileParser.factory(fileName);
-//      }
-//
-//      List<OdeMsgPayload> payloadList = new ArrayList<>();
-//      do {
-//         try {
-//            status = fileParser.parseFile(bis, fileName);
-//            if (status == ParserStatus.COMPLETE) {
-//               parsePayload(payloadList);
-//            } else if (status == ParserStatus.EOF) {
-//               publish(xmlUtils, payloadList);
-//            } else if (status == ParserStatus.INIT) {
-//               logger.error("Failed to parse the header bytes.");
-//            } else {
-//               logger.error("Failed to decode ASN.1 data");
-//            }
-//         } catch (Exception e) {
-//            throw new LogFileToAsn1CodecPublisherException("Error parsing or publishing data.", e);
-//         }
-//      } while (status == ParserStatus.COMPLETE);
-//   }
-
-   
-   // TODO - This needs to be redesigned to publish a proprietary schema
-   
-//   public void parsePayload(List<OdeMsgPayload> payloadList) {
-//
-//      OdeMsgPayload msgPayload;
-//      
-//      if (fileParser instanceof DriverAlertFileParser){
-//         msgPayload = new OdeDriverAlertPayload(((DriverAlertFileParser) fileParser).getAlert());
-//      } else {
-//         msgPayload = new OdeAsn1Payload(fileParser.getPayloadParser().getPayload());
-//      }
-//
-//      payloadList.add(msgPayload);
-//   }
-//
-//   public void publish(XmlUtils xmlUtils, List<OdeMsgPayload> payloadList) throws JsonProcessingException {
-//     serialId.setBundleSize(payloadList.size());
-//     for (OdeMsgPayload msgPayload : payloadList) {
-//       OdeLogMetadata msgMetadata;
-//       OdeData msgData;
-//       
-//       if (fileParser instanceof DriverAlertFileParser){
-//          logger.debug("Publishing a driverAlert.");
-//
-//          msgMetadata = new OdeLogMetadata(msgPayload);
-//          msgMetadata.setSerialId(serialId);
-//
-//          OdeLogMetadataCreatorHelper.updateLogMetadata(msgMetadata, fileParser);
-//          
-//          msgData = new OdeDriverAlertData(msgMetadata, msgPayload);
-//          publisher.publish(JsonUtils.toJson(msgData, false),
-//             publisher.getOdeProperties().getKafkaTopicDriverAlertJson());
-//          serialId.increment();
-//       } else {
-//          if (fileParser instanceof BsmLogFileParser || 
-//                (fileParser instanceof RxMsgFileParser && ((RxMsgFileParser)fileParser).getRxSource() == RxSource.RV)) {
-//             logger.debug("Publishing a BSM");
-//             msgMetadata = new OdeBsmMetadata(msgPayload);
-//          } else {
-//             logger.debug("Publishing a TIM");
-//             msgMetadata = new OdeLogMetadata(msgPayload);
-//          }
-//          msgMetadata.setSerialId(serialId);
-//
-//          Asn1Encoding msgEncoding = new Asn1Encoding("root", "Ieee1609Dot2Data", EncodingRule.COER);
-//          Asn1Encoding unsecuredDataEncoding = new Asn1Encoding("unsecuredData", "MessageFrame",
-//                  EncodingRule.UPER);
-//          msgMetadata.addEncoding(msgEncoding).addEncoding(unsecuredDataEncoding);
-//
-//          OdeLogMetadataCreatorHelper.updateLogMetadata(msgMetadata, fileParser);
-//          
-//          msgData = new OdeAsn1Data(msgMetadata, msgPayload);
-//          publisher.publish(xmlUtils.toXml(msgData),
-//             publisher.getOdeProperties().getKafkaTopicAsn1DecoderInput());
-//          serialId.increment();
-//       }
-//     }
-//   }
-
-
+   public void publishRecordList(List<Record> recordList) {
+      for (Record record: recordList) {
+         publisher.publish(record);
+      }
+   }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/codec/utils/JsonUtils.java
+++ b/src/main/java/us/dot/its/jpo/ingest/codec/utils/JsonUtils.java
@@ -1,0 +1,34 @@
+package us.dot.its.jpo.ingest.codec.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+public class JsonUtils {
+   
+   private static Gson gsonCompact;
+   private static Gson gsonVerbose;
+   private static ObjectMapper mapper;
+   
+   static {
+      gsonCompact = new GsonBuilder().create();
+      gsonVerbose = new GsonBuilder().serializeNulls().create();
+      setMapper(new ObjectMapper());
+   }
+   
+   public static String toJson(Object o, boolean verbose) {
+
+      // convert java object to JSON format,
+      // and returned as JSON formatted string
+      return verbose ? gsonVerbose.toJson(o) : gsonCompact.toJson(o);
+   }
+
+   public static ObjectMapper getMapper() {
+      return mapper;
+   }
+
+   public static void setMapper(ObjectMapper mapper) {
+      JsonUtils.mapper = mapper;
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/kafka/StringPublisher.java
+++ b/src/main/java/us/dot/its/jpo/ingest/kafka/StringPublisher.java
@@ -1,7 +1,13 @@
 package us.dot.its.jpo.ingest.kafka;
 
-public class StringPublisher {
-   
-   // TODO - implement
+import us.dot.its.jpo.ingest.codec.utils.JsonUtils;
+import us.dot.its.jpo.ingest.pojos.Record;
 
+public class StringPublisher {
+
+   public void publish(Record record) {
+      // TODO - implement
+
+      String jsonRecord = JsonUtils.toJson(record, false);
+   }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/BsmLogFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/BsmLogFileParser.java
@@ -20,6 +20,10 @@ import java.io.BufferedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.ReceivedMsgRecord;
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public class BsmLogFileParser extends LogFileParser {
    
    // TODO - ripped from OdeBsmMetadata class
@@ -108,5 +112,16 @@ public class BsmLogFileParser extends LogFileParser {
             code, 0, BsmSource.values());
          setBsmSource(BsmSource.unknown);
       }
+   }
+   
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      ReceivedMsgRecord curRecord = new ReceivedMsgRecord();
+      curRecord.setLength(this.payloadParser.getPayloadLength());
+      curRecord.setLogLocation(this.locationParser.getLocation());
+      curRecord.setMsec(this.timeParser.getmSec());
+      curRecord.setPayload(this.payloadParser.getPayload());
+      curRecord.setUtcTimeInSec(this.timeParser.getUtcTimeInSec());
+      return curRecord;
    }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/DistressMsgFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/DistressMsgFileParser.java
@@ -17,6 +17,10 @@ package us.dot.its.jpo.ingest.parsers;
 
 import java.io.BufferedInputStream;
 
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.ReceivedMsgRecord;
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public class DistressMsgFileParser extends LogFileParser {
 
    public DistressMsgFileParser() {
@@ -69,5 +73,16 @@ public class DistressMsgFileParser extends LogFileParser {
 
       return status;
 
+   }
+   
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      ReceivedMsgRecord curRecord = new ReceivedMsgRecord();
+      curRecord.setLength(this.payloadParser.getPayloadLength());
+      curRecord.setLogLocation(this.locationParser.getLocation());
+      curRecord.setMsec(this.timeParser.getmSec());
+      curRecord.setPayload(this.payloadParser.getPayload());
+      curRecord.setUtcTimeInSec(this.timeParser.getUtcTimeInSec());
+      return curRecord;
    }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/DriverAlertFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/DriverAlertFileParser.java
@@ -17,6 +17,10 @@ package us.dot.its.jpo.ingest.parsers;
 
 import java.io.BufferedInputStream;
 
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.ReceivedMsgRecord;
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public class DriverAlertFileParser extends LogFileParser {
 
    private String alert;
@@ -72,6 +76,17 @@ public class DriverAlertFileParser extends LogFileParser {
 
    public void setAlert(byte[] alert) {
       this.alert = new String(alert);
+   }
+   
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      ReceivedMsgRecord curRecord = new ReceivedMsgRecord();
+      curRecord.setLength(this.payloadParser.getPayloadLength());
+      curRecord.setLogLocation(this.locationParser.getLocation());
+      curRecord.setMsec(this.timeParser.getmSec());
+      curRecord.setPayload(this.payloadParser.getPayload());
+      curRecord.setUtcTimeInSec(this.timeParser.getUtcTimeInSec());
+      return curRecord;
    }
 
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/FileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/FileParser.java
@@ -17,6 +17,8 @@ package us.dot.its.jpo.ingest.parsers;
 
 import java.io.BufferedInputStream;
 
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public interface FileParser {
 
    public static class FileParserException extends Exception {
@@ -37,4 +39,6 @@ public interface FileParser {
    }
 
    public ParserStatus parseFile(BufferedInputStream bis, String fileName) throws FileParserException;
+
+   public Record getCurrentRecord() throws FileParserException;
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/LocationParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/LocationParser.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.nio.ByteOrder;
 
 import us.dot.its.jpo.ingest.codec.utils.CodecUtils;
+import us.dot.its.jpo.ingest.pojos.LogLocation;
 
 public class LocationParser extends LogFileParser {
 

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/LogFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/LogFileParser.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public abstract class LogFileParser implements FileParser {
    
    // TODO - ripped from OdeLogMetadata class
@@ -186,6 +189,11 @@ public abstract class LogFileParser implements FileParser {
 
    public void setPayloadParser(PayloadParser payloadParser) {
       this.payloadParser = payloadParser;
+   }
+   
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      throw new FileParserException(this.getClass().getSimpleName() + " is not appropriate for sending full records");
    }
 
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/PayloadParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/PayloadParser.java
@@ -83,9 +83,4 @@ public class PayloadParser extends LogFileParser {
       return this;
    }
 
-   @Override
-   public Record getCurrentRecord() throws FileParserException {
-      throw new FileParserException("PayloadParser cannot return full records");
-   }
-
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/PayloadParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/PayloadParser.java
@@ -20,6 +20,7 @@ import java.nio.ByteOrder;
 import java.util.Arrays;
 
 import us.dot.its.jpo.ingest.codec.utils.CodecUtils;
+import us.dot.its.jpo.ingest.pojos.Record;
 
 public class PayloadParser extends LogFileParser {
 
@@ -80,6 +81,11 @@ public class PayloadParser extends LogFileParser {
    public LogFileParser setPayload(byte[] payload) {
       this.payload = payload;
       return this;
+   }
+
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      throw new FileParserException("PayloadParser cannot return full records");
    }
 
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/RxMsgFileParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/RxMsgFileParser.java
@@ -20,6 +20,10 @@ import java.io.BufferedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.ReceivedMsgRecord;
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public class RxMsgFileParser extends LogFileParser {
    
    // TODO - ripped from ODE RxSource class in core/common
@@ -109,5 +113,16 @@ public class RxMsgFileParser extends LogFileParser {
             rxSourceOrdinal, RxSource.values());
          setRxSource(RxSource.unknown);
       }
+   }
+   
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      ReceivedMsgRecord curRecord = new ReceivedMsgRecord();
+      curRecord.setLength(this.payloadParser.getPayloadLength());
+      curRecord.setLogLocation(this.locationParser.getLocation());
+      curRecord.setMsec(this.timeParser.getmSec());
+      curRecord.setPayload(this.payloadParser.getPayload());
+      curRecord.setUtcTimeInSec(this.timeParser.getUtcTimeInSec());
+      return curRecord;
    }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/SecurityResultCodeParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/SecurityResultCodeParser.java
@@ -20,6 +20,9 @@ import java.io.BufferedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.Record;
+
 public class SecurityResultCodeParser extends LogFileParser {
    
    // TODO - ripped from OdeLogMetadata
@@ -113,5 +116,4 @@ public class SecurityResultCodeParser extends LogFileParser {
          setSecurityResultCode(SecurityResultCode.unknown);
       }
    }
-
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/TimeParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/TimeParser.java
@@ -88,9 +88,4 @@ public class TimeParser extends LogFileParser {
    public ZonedDateTime getGeneratedAt() {
       return DateTimeUtils.isoDateTime(getUtcTimeInSec() * 1000 + getmSec());
    }
-   
-   @Override
-   public Record getCurrentRecord() throws FileParserException {
-      throw new FileParserException("PayloadParser cannot return full records");
-   }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/parsers/TimeParser.java
+++ b/src/main/java/us/dot/its/jpo/ingest/parsers/TimeParser.java
@@ -21,6 +21,8 @@ import java.time.ZonedDateTime;
 
 import us.dot.its.jpo.ingest.codec.utils.CodecUtils;
 import us.dot.its.jpo.ingest.codec.utils.DateTimeUtils;
+import us.dot.its.jpo.ingest.parsers.FileParser.FileParserException;
+import us.dot.its.jpo.ingest.pojos.Record;
 
 public class TimeParser extends LogFileParser {
 
@@ -85,5 +87,10 @@ public class TimeParser extends LogFileParser {
 
    public ZonedDateTime getGeneratedAt() {
       return DateTimeUtils.isoDateTime(getUtcTimeInSec() * 1000 + getmSec());
+   }
+   
+   @Override
+   public Record getCurrentRecord() throws FileParserException {
+      throw new FileParserException("PayloadParser cannot return full records");
    }
 }

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/AbstractLogFileRecord.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/AbstractLogFileRecord.java
@@ -1,0 +1,50 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public abstract class AbstractLogFileRecord implements Record {
+
+   private LogLocation curLocation;
+   private long utcTimeInSec;
+   private int msec;
+   private int length;
+   private byte[] payload;
+
+   public LogLocation getLogLocation() {
+      return curLocation;
+   }
+
+   public void setLogLocation(LogLocation logLocation) {
+      this.curLocation = logLocation;
+   }
+
+   public long getUtcTimeInSec() {
+      return utcTimeInSec;
+   }
+
+   public void setUtcTimeInSec(long utcTimeInSec) {
+      this.utcTimeInSec = utcTimeInSec;
+   }
+
+   public int getMsec() {
+      return msec;
+   }
+
+   public void setMsec(int msec) {
+      this.msec = msec;
+   }
+
+   public int getLength() {
+      return length;
+   }
+
+   public void setLength(int length) {
+      this.length = length;
+   }
+
+   public byte[] getPayload() {
+      return payload;
+   }
+
+   public void setPayload(byte[] payload) {
+      this.payload = payload;
+   }
+}

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/AbstractVerifiedMsgRecord.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/AbstractVerifiedMsgRecord.java
@@ -1,0 +1,15 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public abstract class AbstractVerifiedMsgRecord extends AbstractLogFileRecord {
+   
+   private int verficationStatus;
+
+   public int getVerficationStatus() {
+      return verficationStatus;
+   }
+
+   public void setVerficationStatus(int verficationStatus) {
+      this.verficationStatus = verficationStatus;
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/BsmLogRecHeader.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/BsmLogRecHeader.java
@@ -1,0 +1,19 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public class BsmLogRecHeader extends AbstractLogFileRecord {
+   
+   private int signStatus;
+   
+   public BsmLogRecHeader () {
+      super();
+   }
+
+   public int getSignStatus() {
+      return signStatus;
+   }
+
+   public void setSignStatus(int signStatus) {
+      this.signStatus = signStatus;
+   }
+   
+}

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/DnsMsgRecord.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/DnsMsgRecord.java
@@ -1,0 +1,9 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public class DnsMsgRecord extends AbstractVerifiedMsgRecord {
+   
+   public DnsMsgRecord() {
+      super();
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/DriverAlertRecord.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/DriverAlertRecord.java
@@ -1,0 +1,9 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public class DriverAlertRecord extends AbstractLogFileRecord {
+
+   public DriverAlertRecord() {
+      super();
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/LogLocation.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/LogLocation.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  ******************************************************************************/
-package us.dot.its.jpo.ingest.parsers;
+package us.dot.its.jpo.ingest.pojos;
 
 /**
  * POJO class for TIM log file location data

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/ReceivedMsgRecord.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/ReceivedMsgRecord.java
@@ -1,0 +1,9 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public class ReceivedMsgRecord extends AbstractVerifiedMsgRecord {
+   
+   public ReceivedMsgRecord() {
+      super();
+   }
+
+}

--- a/src/main/java/us/dot/its/jpo/ingest/pojos/Record.java
+++ b/src/main/java/us/dot/its/jpo/ingest/pojos/Record.java
@@ -1,0 +1,4 @@
+package us.dot.its.jpo.ingest.pojos;
+
+public interface Record {
+}


### PR DESCRIPTION
### Summary
Adds POJOs for the four supported log file type records.

There may be a more elegant way to populate these POJOs and improve the file parsing inheritance for code reuse, for when we revisit this task in the future.

### TODO
- Kafka publishing needs to be implemented
- VerificationStatus needs to be populated (where does this come from?)
- Other misc fields should be populated